### PR TITLE
correct broken internal links

### DIFF
--- a/docs/cookbook/real-time.md
+++ b/docs/cookbook/real-time.md
@@ -87,7 +87,7 @@ Every peer need it's own sync state. You can initialize a new sync state using `
 syncStates[peerId][docId] = Automerge.initSyncState()
 ```
 
-Automerge keeps track of ongoing exchanges with another peer using a `syncState` data structure. During synchronization, Automerge uses a probabilistic structure known as a Bloom filter to avoid having to send the full descriptions of every local change to peers. To reduce the size and cost of this structure, it is only built for changes the other peer has not already told us they have. This is described in more detail later in the [Internals section](docs/how-it-works/sync). 
+Automerge keeps track of ongoing exchanges with another peer using a `syncState` data structure. During synchronization, Automerge uses a probabilistic structure known as a Bloom filter to avoid having to send the full descriptions of every local change to peers. To reduce the size and cost of this structure, it is only built for changes the other peer has not already told us they have. This is described in more detail later in the [Internals section](/docs/how-it-works/sync). 
 
 To maintain this structure, when a peer is discovered, first create a new `syncState` via `initSyncState()`. These `syncState` objects can be persisted between program executions as an optimization, but it is not required. All subsequent sync operations with that peer will return a new `syncState` to replace the previous one.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # 5 minute quick start
 
-This guide will get you up and running with Automerge in your own application. This guide is recommended for you if you have strong understanding of JavaScript fundamentals and CRDTs. If you find this quick start to be complicated, we recommend trying the [Tutorial](docs/tutorial/introduction) section.
+This guide will get you up and running with Automerge in your own application. This guide is recommended for you if you have strong understanding of JavaScript fundamentals and CRDTs. If you find this quick start to be complicated, we recommend trying the [Tutorial](/docs/tutorial/introduction) section.
 
 
 ## Setup

--- a/docs/tutorial/setup.md
+++ b/docs/tutorial/setup.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 ---
 # Setup
 
-We will build a small web app during this tutorial. This tutorial is designed to walk you through the basic concepts of Automerge so that you can use it in your own apps. For a deeper understanding and common patterns that you would likely need in a production application, see the [Cookbook](docs/cookbook/modeling-data). You will find that these two resources are complementary.
+We will build a small web app during this tutorial. This tutorial is designed to walk you through the basic concepts of Automerge so that you can use it in your own apps. For a deeper understanding and common patterns that you would likely need in a production application, see the [Cookbook](/docs/cookbook/modeling-data). You will find that these two resources are complementary.
  
 ## What you need to know
 

--- a/docs/tutorial/sync-changes.md
+++ b/docs/tutorial/sync-changes.md
@@ -116,7 +116,7 @@ function updatePeers (doc) {
 
 Now, you should be able to add and toggle todo items on both sides and see the changes!
 
-For more information about the sync protocol, and a more advanced example for multiple peers, see the [Cookbook](docs/cookbook/real-time).
+For more information about the sync protocol, and a more advanced example for multiple peers, see the [Cookbook](/docs/cookbook/real-time).
 
 ## Hints
 


### PR DESCRIPTION
Hey!

I was spending a lazy Sunday grazing the (new?) automerge docs and noticed a couple of the internal links were broken. I searched for other potentially broken links, found some and fixed those as well. Tested using a local install of Docusaurus to verify that the links are _actually_ fixed.

Thanks @okdistribute for the site! It's a big improvement over trying to puzzle together the Automerge picture from uncoupled markdown documents, or through watching talks (nothing really replaces reading docs & code examples imo :~)