### PR TITLE
Quickstart fix

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -44,9 +44,9 @@ doc1 = Automerge.change(doc1, 'Add card', doc => {
   doc.cards.push({ title: 'Rewrite everything in Clojure', done: false })
   doc.cards.push({ title: 'Rewrite everything in Haskell', done: false })
 })
-// { cards: [ 
-//    { title: 'Rewrite everything in Haskell', done: false },
-//    { title: 'Rewrite everything in Clojure', done: false } ]} 
+// { cards: [
+//    { title: 'Rewrite everything in Clojure', done: false },
+//    { title: 'Rewrite everything in Haskell', done: false } ]}
 ```
 
 `Automerge.change(doc, [message], changeFn)` enables you to modify an Automerge document `doc`,
@@ -95,7 +95,7 @@ Now comes the moment of truth. Let's merge the changes again. You can also do th
 
 ```js
 let finalDoc = Automerge.merge(doc1, doc2)
-// { cards: [ { title: 'Rewrite everything in Haskell', done: true } ] }
+// { cards: [ { title: 'Rewrite everything in Clojure', done: true } ] }
 ```
 
 ## Get change history
@@ -110,13 +110,11 @@ example, we can count how many cards there were at each point:
 
 ```js
 Automerge.getHistory(finalDoc).map(state => [state.change.message, state.snapshot.cards.length])
-// [ [ 'Initialization', 0 ],
-//   [ 'Add card', 1 ],
-//   [ 'Add another card', 2 ],
+// [ [ 'Add card', 2 ],
 //   [ 'Mark card as done', 2 ],
 //   [ 'Delete card', 1 ] ]
 ```
 
 ## More
 
-If you're hungry for more, look in the [Cookbook](cookbook/modeling-data) setion.
+If you're hungry for more, look in the [Cookbook](cookbook/modeling-data) section.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "2.0.0-beta.9",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
+    "automerge": "^1.0.1-preview.7",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
     "prism-react-renderer": "^1.2.1",

--- a/test/quickstart.js
+++ b/test/quickstart.js
@@ -1,0 +1,33 @@
+const Automerge = require('automerge')
+
+let doc1 = Automerge.init()
+
+doc1 = Automerge.change(doc1, 'Add card', doc => {
+  doc.cards = []
+  doc.cards.push({ title: 'Rewrite everything in Clojure', done: false })
+  doc.cards.push({ title: 'Rewrite everything in Haskell', done: false })
+})
+
+console.log("initial doc")
+console.log(doc1)
+
+let doc2 = Automerge.init()
+doc2 = Automerge.merge(doc2, doc1)
+
+doc1 = Automerge.change(doc1, 'Mark card as done', doc => {
+  doc.cards[0].done = true
+})
+doc2 = Automerge.change(doc2, 'Delete card', doc => {
+  delete doc.cards[1]
+})
+
+let finalDoc = Automerge.merge(doc1, doc2)
+console.log("final doc")
+console.log(finalDoc)
+
+const history = Automerge.getHistory(finalDoc).map((state) => [
+  state.change.message,
+  state.snapshot.cards.length,
+]);
+console.log("history")
+console.log(history)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,6 +2225,15 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+automerge@^1.0.1-preview.7:
+  version "1.0.1-preview.7"
+  resolved "https://registry.yarnpkg.com/automerge/-/automerge-1.0.1-preview.7.tgz#6a0cadaa8efbcdb578ed899ac03d7002763e8d2c"
+  integrity sha512-Fz5fJdU59xYYj0viteMKTGg/bQWTyibZlkY3V8VQqx9Do1Eg3jtud2+BAI5ZQiKwdWocXc4KKC5o5vT1dzouag==
+  dependencies:
+    fast-sha256 "^1.3.0"
+    pako "^2.0.3"
+    uuid "^3.4.0"
+
 autoprefixer@^10.3.5, autoprefixer@^10.3.7:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.0.tgz#c3577eb32a1079a440ec253e404eaf1eb21388c8"
@@ -3599,6 +3608,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
 
 fast-url-parser@1.1.3:
   version "1.1.3"
@@ -5471,6 +5485,11 @@ package-json@^6.3.0:
     registry-auth-token "^4.0.0"
     registry-url "^5.0.0"
     semver "^6.2.0"
+
+pako@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -7496,6 +7515,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
This fixes up the output sections in the quickstart guide.

I've also added a `quickstart.js` file which can be run to check the results. I'm wondering if there is a way to have it be preprocessed to run the code blocks and automatically include the output, probably for another time though.