### PR TITLE
redirect Swift API to new API documentation matching Automerge-rs 0.3.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,12 @@
---- 
+---
 sidebar_position: 1000
 ---
 # Other APIs
 
 Here you can find links to the APIs for each implementation.
-  
-  * [Swift/iOS](https://github.com/automerge/automerge-swift)
+
   * [C](https://github.com/automerge/automerge/tree/main/rust/automerge-c)
   * [Rust](https://github.com/automerge/automerge-rs)
   * [Python](https://github.com/automerge/automerge-py)
+  * [Swift (macOS, iOS)](https://automerge.org/automerge-swift/documentation/automerge/)
+


### PR DESCRIPTION
With the Automerge-swift repository move and updates, this updates the documentation links to the new Swift language API pages: https://automerge.org/automerge-swift/documentation/automerge/