### PR TITLE
Update docs

### DIFF
--- a/docs/tutorial/rendering-app.md
+++ b/docs/tutorial/rendering-app.md
@@ -61,8 +61,8 @@ You cannot use `...` when updating a Automerge document. For example, the follow
 
 ```js
 Automerge.change(doc, doc => {
-  doc.items = [...doc.items, toggledItem]
+  doc.items = [...doc.items, toggledItem] // This will overwrite doc.items with a new copy; automerge won't know what actually changed
 })
 ```
 
-Instead, to add an item to a list, you need to use `doc.items.push(item)` inside `Automerge.change` to add to the end of the list. You can also use `doc.items.unshift(item)` to add an item to the beginning, or `doc.items.insertAt(index, item)` to add an item at any index.
+Instead, to add an item to a list, you need to use `doc.items.push(item)` inside `Automerge.change` to add to the end of the list. You can also use `doc.items.unshift(item)` to add an item to the beginning, or `doc.items.insertAt(index, item)` to add an item at any index. For more information, see [types/lists]<../../types/lists/>

--- a/docs/tutorial/rendering-app.md
+++ b/docs/tutorial/rendering-app.md
@@ -65,4 +65,4 @@ Automerge.change(doc, doc => {
 })
 ```
 
-Instead, to add an item to a list, you need to use `doc.items.push(item)` inside `Automerge.change` to add to the end of the list. You can also use `doc.items.unshift(item)` to add an item to the beginning, or `doc.items.insertAt(index, item)` to add an item at any index. For more information, see [types/lists]<../../types/lists/>
+Instead, to add an item to a list, you need to use `doc.items.push(item)` inside `Automerge.change` to add to the end of the list. You can also use `doc.items.unshift(item)` to add an item to the beginning, or `doc.items.insertAt(index, item)` to add an item at any index. For more information, see [the documentation for lists](/docs/types/lists).

--- a/docs/types/lists.md
+++ b/docs/types/lists.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Lists
 
-JavaScript Arrays are fully supported in Automerge. You can use `push`, `unshift`, `insertAt`, `splice`, loops, and nested objects.
+JavaScript Arrays are fully supported in Automerge. You can use `push`, `unshift`, `insertAt`, `deleteAt`, `splice`, loops, and nested objects.
 
 ```js
 newDoc = Automerge.change(currentDoc, doc => {


### PR DESCRIPTION
This PR adds a tutorial comment describing why the immutable array example is bad and a link to [types/lists].
It also adds the `deleteAt` method to [types/lists].