### PR TITLE
fixing broken links

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,8 +3,8 @@ sidebar_position: 1000
 ---
 # API Docs
 
-* [`@automerge/automerge`](http://automerge.org/automerge/api-docs/js)
-* [`@automerge/automerge-repo`](http://automerge.org/automerge-repo/)
+* [`@automerge/automerge`](https://automerge.org/automerge/api-docs/js)
+* [`@automerge/automerge-repo`](https://automerge.org/automerge-repo/)
 
 # Other Languages
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -21,9 +21,9 @@ Automerge as used in javascript applications is actually a composition of two li
 
 A document is the "unit of change" in automerge. It's like a combination of a JSON object and a git repository. What does that mean?
 
-Like a JSON object an automerge document is a map from strings to values, where the values can themselves be maps, arrays, or simple types like strings or numbers. See the [data model](./documents/) section for more details.
+Like a JSON object an automerge document is a map from strings to values, where the values can themselves be maps, arrays, or simple types like strings or numbers. See the [data model](/docs/documents/) section for more details.
 
-Like a git repository an automerge document has a history made up of commits. Every time you make a change to a document you are adding to the history of the document. The combination of this history and some rules about how to handle conflicts means that any two automerge documents can always be merged. See [merging](./merge_rules.md') for the gory details.
+Like a git repository an automerge document has a history made up of commits. Every time you make a change to a document you are adding to the history of the document. The combination of this history and some rules about how to handle conflicts means that any two automerge documents can always be merged. See [merging](/docs/under-the-hood/merge_rules.md) for the gory details.
 
 ### Repositories
 

--- a/docs/documents/index.md
+++ b/docs/documents/index.md
@@ -53,7 +53,7 @@ Counters are a simple CRDT which just merges by adding all concurrent operations
 
 The mapping to javascript is accomplished with the use of proxies. This means that in the javascript library maps appear as `object`s and lists appear as `Array`s. There is only one numeric type in javascript - `number` - so the javascript library guesses a bit. If you insert a javascript `number` for which [`Number.isInteger`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger) returns `true` then the number will be inserted as an integer, otherwise it will be a floating point value.
 
-How `Text` and `String` are represented will depend on whether you are using [the `next` API](/docs/working_with_js#the-next-api)
+How `Text` and `String` are represented will depend on whether you are using [the `next` API](/docs/the_js_packages#the-next-api)
 
 Timestamps are represented as javascript `Date`s.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,7 @@ Automerge is a type of CRDT (Conflict-Free Replicated Datatype). A CRDT is a dat
 
 Applications built with Automerge are *eventually consistent.* This means if several users are working together, they will *eventually* all see the same application state, but at any given moment it's possible for the users to be temporarily out of sync.
 
-Eventual consistency allows applications to work offline: even if a user is disconnected from the internet, Automerge allows that user to view and modify their data. If the data is shared between several users, they may all update their data independently. Later, when a network is available again, Automerge ensures that those edits are cleanly merged. See the page on [conflicts](/docs/cookbook/conflicts/) for more detail on these merges.
+Eventual consistency allows applications to work offline: even if a user is disconnected from the internet, Automerge allows that user to view and modify their data. If the data is shared between several users, they may all update their data independently. Later, when a network is available again, Automerge ensures that those edits are cleanly merged. See the page on [conflicts](/docs/documents/conflicts/) for more detail on these merges.
 
 ## Documents
 
@@ -27,7 +27,7 @@ A document is a collection of data that holds the current state of the applicati
 
 ## Types
 
-All collaborative data structures conform to certain rules. Each variable in the document must be of one of the implemented types. Each type must conform to the rules of CRDTs. Automerge comes with a set of [pre-defined types](/docs/types/values/) such as `Map`, `Array`, `Counter`, `number`, `Text`, and so on.
+All collaborative data structures conform to certain rules. Each variable in the document must be of one of the implemented types. Each type must conform to the rules of CRDTs. Automerge comes with a set of [pre-defined types](/docs/documents/values) such as `Map`, `Array`, `Counter`, `number`, `Text`, and so on.
 
 ## Changes
 

--- a/docs/hello.md
+++ b/docs/hello.md
@@ -30,7 +30,7 @@ to be synced from one device to another, and brings them into the same state.
   kind of network you use. It works with any connection-oriented network protocol, which could be
   client/server (e.g. WebSocket), peer-to-peer (e.g. WebRTC), or entirely local (e.g. Bluetooth).
   Bindings to particular networking technologies are handled by separate libraries;
-  see the page on [real-time collaboration](/docs/cookbook/real-time/) for examples.
+  Automerge provides [automerge-repo](https://automerge.org/automerge-repo/index.html) for a common collection of these libraries.
   It also works with unidirectional messaging: you can send an Automerge file as email attachment,
   or on a USB drive in the mail, and the recipient will be able to merge it with their version.
 - **Immutable state**. An Automerge object is an immutable snapshot of the application state at one

--- a/docs/the_js_packages.md
+++ b/docs/the_js_packages.md
@@ -19,7 +19,7 @@ Over time we have made a number of changes to the automerge API which are not ba
 
 ### Differences from stable
 
-* In the old API javascript strings are represented as scalar strings (see the [data model](./concepts/data_model.md) for details) whilst in "next" javascript strings are `Text` sequences (i.e. they support concurrent insertions and deletions). This means that you should use `next.splice` to modify strings in the `next` API. Scalar strings in the `next` API are represented as instances of the `RawString` class.
+* In the old API javascript strings are represented as scalar strings (see the [data model](/docs/documents/) for details) whilst in "next" javascript strings are `Text` sequences (i.e. they support concurrent insertions and deletions). This means that you should use `next.splice` to modify strings in the `next` API. Scalar strings in the `next` API are represented as instances of the `RawString` class.
 * The next API exposes the `diff` and `changeAt` methods
 
 ### Using the next API


### PR DESCRIPTION
resolves #46 (well, most of the broken links reported in #46)

The notable one that it doesn't is the tutorial, which no longer exists as a separate directory, and I wasn't sure where that was relocated into or what the future plans were. It's a broken link on the blog announcement talking about Automerge v2.