### PR TITLE
Add API reference links in navbar dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,6 +74,25 @@ const config = {
                         label: 'Docs',
                     },
                     {
+                        type: 'dropdown',
+                        label: 'API Reference',
+                        position: 'left',
+                        items: [
+                            {
+                                label: 'JavaScript',
+                                href: 'https://automerge.org/automerge/api-docs/js/',
+                            },
+                            {
+                                label: 'Rust',
+                                href: 'https://docs.rs/automerge/latest/automerge/',
+                            },
+                            {
+                                label: 'Swift',
+                                href: 'https://automerge.org/automerge-swift/documentation/automerge/',
+                            },
+                        ],
+                    },
+                    {
                         href: 'https://github.com/automerge',
                         label: 'GitHub',
                         position: 'right',


### PR DESCRIPTION
This adds a dropdown to the navbar with a couple of links for the API reference for JS and Rust versions of Automerge. I can add more, but just wanted to see folks agree with the direction first.

https://github.com/automerge/automerge.github.io/assets/864752/b697bf0c-4b78-4cbb-80df-74cb382ead47

