### PR TITLE
Scale code font size relative to parent

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,7 +7,7 @@
 
 :root {
   --ifm-font-size-base: 1rem;
-  --ifm-code-font-size: 0.9rem;
+  --ifm-code-font-size: 0.9em;
   --ifm-font-family-base: 'Merriweather', serif;
   --ifm-heading-font-family: Overpass, sans-serif;
   --ifm-color-primary: #fbcc34;
@@ -124,4 +124,5 @@ code {
   display: inline-block;
   padding: 0 0.3rem;
   margin: 0 0.1rem;
+  vertical-align: baseline;
 }


### PR DESCRIPTION
Before:

<img width="1160" alt="image" src="https://github.com/automerge/automerge.github.io/assets/1682194/3392f9c7-176e-41d6-8b9d-29a1adf8e105">

After:

<img width="1162" alt="image" src="https://github.com/automerge/automerge.github.io/assets/1682194/b1c73b2f-b1a8-4d99-8f40-be3bb102885c">
