### PR TITLE
Fix example networking express.js code

### DIFF
--- a/docs/repositories/networking.md
+++ b/docs/repositories/networking.md
@@ -34,14 +34,14 @@ import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket
 import express from "express";
 
 const wss = new WebSocketServer({ noServer: true });
-const server = express();
+const app = express();
+const server = app.listen(8080);
 server.on("upgrade", (request, socket, head) => {
   wss.handleUpgrade(request, socket, head, (socket) => {
     wss.emit("connection", socket, request);
   });
 });
 const adapter = new NodeWSServerAdapter(wss);
-server.listen(8080);
 ```
 
 ### Client


### PR DESCRIPTION
https://automerge.org/docs/repositories/networking/

The previous code example doesn't compile. For comparison, check https://github.com/automerge/automerge-repo-sync-server/blob/main/src/server.js

I'd also considering adding the example repo's link to the docs, as it contains pretty useful full example code.