### PR TITLE
Update vite config to work when running `pnpm build`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -50,6 +50,10 @@ export default defineConfig({
     format: 'es',
     plugins: () => [wasm()],
   },
+
+  build: {
+    target: "esnext",
+  },
 })
 ```
 


### PR DESCRIPTION
Without it you will get the following error:

```
ERROR: Top-level await is not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari14" + 2 overrides)
```