### PR TITLE
Document the fact that you can't set a property to undefined

### DIFF
--- a/docs/documents/values.md
+++ b/docs/documents/values.md
@@ -27,6 +27,6 @@ newDoc = Automerge.change(currentDoc, (doc) => {
   // cases where you want a string which is not collaborative - URLs for example
   // should generally be updated in one go. In this case you can use `RawString`,
   // which does not allow concurrent updates.
-  doc.atomicStringValue = new Automerge.RawString("")
+  doc.atomicStringValue = new Automerge.RawString("");
 });
 ```

--- a/docs/documents/values.md
+++ b/docs/documents/values.md
@@ -4,7 +4,10 @@ sidebar_position: 2
 
 # Simple Values
 
-All JSON primitive datatypes are supported in an Automerge document. In addition, JavaScript [Date objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) are supported.
+All JSON primitive datatypes (`object`, `array`, `string`, `number`, `boolean`, `null`) are
+supported in an Automerge document. In addition, JavaScript [Date
+objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) are
+supported.
 
 _Remember, never modify `currentDoc` directly, only ever change `doc` inside the callback to `Automerge.change`!_
 
@@ -30,3 +33,18 @@ newDoc = Automerge.change(currentDoc, (doc) => {
   doc.atomicStringValue = new Automerge.RawString("");
 });
 ```
+
+:::caution  
+Note that `undefined` is not a valid JSON value, and it can't be used in an Automerge document.
+:::
+
+This will throw an error:
+
+```js
+newdoc = Automerge.change(currentDoc, (doc) => {
+  doc.something = undefined; // ❌ Cannot assign undefined value at /something
+});
+```
+
+Instead, you might consider setting a property's value to `null`, or using `delete` to remove it
+altogether.

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^3.17.1",
     "typescript": "^5.4.5"
+  },
+  "prettier": {
+    "singleQuote": false
   }
 }


### PR DESCRIPTION
This PR is a companion to https://github.com/automerge/automerge/pull/927

Adds a note to clarify in the docs that an Automerge value cannot be `undefined`. 


![image](https://github.com/automerge/automerge.github.io/assets/2136620/d5ceac1d-a516-4057-bc08-dc408e3dbb84)
