### PR TITLE
Add docs about how to initialize the webassembly

### DIFF
--- a/docs/the_js_packages.md
+++ b/docs/the_js_packages.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # The JavaScript packages

--- a/docs/under-the-hood/_category_.json
+++ b/docs/under-the-hood/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Under the hood",
-  "position": 5
+  "position": 6
 }


### PR DESCRIPTION
This PR adds some docs for the new features which are intended to make it easier to load Automerge in environments which don't support importing WebAssembly as ES modules.

You can test all this out using the `@automerge/automerge@2.2.3-alpha.0` and `@automerge/automerge-repo@1.2.0-alpha.0` releases.