### PR TITLE
Fix example

### DIFF
--- a/docs/documents/index.md
+++ b/docs/documents/index.md
@@ -71,7 +71,7 @@ let doc = A.from({
   },
   list: ["a", "b", "c", { nested: "map" }, ["nested list"]],
   // Note we are using the `next` API for text, so text sequences are strings
-  text: "some text",
+  text: "world",
   // In the `next` API non mergable strings are instances of `RawString`.
   // You should generally not need to use these. They are retained for backward
   // compatibility


### PR DESCRIPTION
The resulting text after the edit is “Hello world” (in the comment below), so it needs to be “world” here.