### PR TITLE
Fix use of Automerge input in escape hatch code

### DIFF
--- a/docs/library_initialization.md
+++ b/docs/library_initialization.md
@@ -138,7 +138,7 @@ import wasmUrl from "@automerge/automerge/automerge.wasm?url";
 import { next as Automerge } from "@automerge/automerge/slim";
 import { Repo } from `@automerge/automerge-repo/slim`;
 
-await next.initializeWasm(wasmUrl)
+await Automerge.initializeWasm(wasmUrl)
 
 // Now we can get on with our lives
 
@@ -155,7 +155,7 @@ import { automergeWasmBase64 } from "@automerge/automerge/automerge.wasm.base64.
 import { next as Automerge } from "@automerge/automerge/slim";
 import { Repo } from `@automerge/automerge-repo/slim`;
 
-await next.initializeBase64Wasm(automergeWasmBase64)
+await Automerge.initializeBase64Wasm(automergeWasmBase64)
 
 // Now we can get on with our lives
 const repo = new Repo({..})


### PR DESCRIPTION
we `import {next as Automerge}` but then we were trying to use it as `next` rather than `Automerge`

:)