### PR TITLE
Fix github link example leading to 404 page

### DIFF
--- a/docs/cookbook/rich-text-prosemirror-react.md
+++ b/docs/cookbook/rich-text-prosemirror-react.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Automerge supports rich text editing on top of [ProseMirror](https://prosemirror.net/). This guide will show you how to set up a simple collaborative rich text editor in React using Automerge and ProseMirror.
 
-All the code here can be found at https://github.com/automerge/automerge-prosemirror/examples/react
+All the code here can be found at https://github.com/automerge/automerge-prosemirror/tree/main/examples/react
 
 First, create a an example vite app using the `@automerge/vite-app` template. This will give you a basic React app with the Automerge dependencies already installed.
 


### PR DESCRIPTION
Fix: edit link to an example on github

Previous version leading to 404 page
![image](https://github.com/user-attachments/assets/2fa6a3d5-8079-4a6e-809c-6b2fbd7cd034)

Edited to a valid link
![image](https://github.com/user-attachments/assets/4ae17fe8-cba7-4d79-a13c-f5b030c3dc49)
