### PR TITLE
Fix some broken anchors in links

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,7 +12,7 @@ This documentation is mostly focused on the javascript implementation of automer
 
 ## Core concepts
 
-Using automerge means storing your data in automerge [documents](#Documents). Documents have [URL](#Document-URLs)s which you can use to share or request documents with/from other peers using a [repository](#Repositories). Repositories give you [`DocHandle`](#dochandles)s which you use to make changes to the document and listen for changes from other peers.
+Using automerge means storing your data in automerge [documents](#documents). Documents have [URL](#document-urls)s which you can use to share or request documents with/from other peers using a [repository](#repositories). Repositories give you [`DocHandle`](#dochandles)s which you use to make changes to the document and listen for changes from other peers.
 
 Automerge as used in javascript applications is actually a composition of two libraries. [`automerge-repo`](https://www.npmjs.com/package/@automerge/automerge-repo) which provides the networking and storage plumbing, and [`automerge`](https://www.npmjs.com/package/@automerge/automerge) which provides the CRDT implementation, a transport agnostic [sync protocol](#sync-protocol), and a compressed [storage format](#storage-format) which `automerge-repo` uses to implement various networking and storage plugins.
 


### PR DESCRIPTION
These were broken for me in FF on macOS when capitalized, though they did work when previewing the markdown file in the GitHub UI.