### PR TITLE
Split out link text-decoration properties for Safari compatibility

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -75,6 +75,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
 a {
   --ifm-link-color: var(--ifm-color-content);
   text-decoration-skip-ink: none;
+  text-decoration-color: var(--ifm-link-decoration-color);
+  text-decoration-thickness: var(--ifm-link-decoration-thickness);
 }
 
 a:hover,
@@ -83,11 +85,15 @@ a:hover,
 .table-of-contents__link:hover code,
 .table-of-contents__link--active code {
   color: inherit;
+  text-decoration-color: var(--ifm-link-decoration-color);
+  text-decoration-thickness: var(--ifm-link-decoration-thickness);
 }
 
 article a {
-  --ifm-link-decoration: underline 3px solid var(--ifm-color-primary);
-  --ifm-link-hover-decoration: underline 3px solid var(--ifm-color-primary);
+  --ifm-link-decoration: underline;
+  --ifm-link-decoration-color: var(--ifm-color-primary);
+  --ifm-link-decoration-thickness: 3px;
+  --ifm-link-hover-decoration: underline;
 }
 
 article div {
@@ -102,7 +108,9 @@ article div {
 .navbar__link:hover,
 .navbar__brand:hover {
   color: inherit;
-  text-decoration: underline 3px solid var(--ifm-color-primary) !important;
+  text-decoration-line: underline !important;
+  text-decoration-color: var(--ifm-color-primary) !important;
+  text-decoration-thickness: 3px !important;
 }
 
 .navbar__title {


### PR DESCRIPTION
Safari [doesn’t support](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration#browser_compatibility) specifying text-decoration-thickness in the text-decoration shorthand. Beyond that, Safari also seems to have trouble handling CSS custom properties within the shorthand syntax. So I just split out the individual `text-decoration-color` and `text-decoration-thickness` properties into their own declarations and custom properties and defined them as needed.

To illustrate the issue, here’s how the Setup part of the A Builder’s Tour of Automerge looks on desktop Safari:

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/99feda51-e871-4d41-a8c1-a1b442d0c406">

(initially i was just confused why the Info box, for example, didn’t link to the repo where i could find the code mentioned there)