### PR TITLE
Update 05-react.mdx

### DIFF
--- a/docs/tutorial/05-react.mdx
+++ b/docs/tutorial/05-react.mdx
@@ -157,7 +157,7 @@ export const TaskList: React.FC<{
   // highlight-start
   const [doc, changeDoc] = useDocument<TaskList>(docUrl, {
     // This hooks the `useDocument` into reacts suspense infrastructure so the whole component
-    // only renderes once the document is loaded
+    // only renders once the document is loaded
     suspense: true,
   });
 
@@ -230,7 +230,7 @@ export const TaskList: React.FC<{
 }> = ({ docUrl }) => {
   const [doc, changeDoc] = useDocument<TaskList>(docUrl, {
     // This hooks the `useDocument` into reacts suspense infrastructure so the whole component
-    // only renderes once the document is loaded
+    // only renders once the document is loaded
     suspense: true,
   });
 


### PR DESCRIPTION
Typo `renderes` -> `renders`

Noticed while reading https://automerge.org/docs/tutorial/react/