### PR TITLE
tutorial: WebSocketClientAdapter appears too early

### DIFF
--- a/docs/tutorial/03-local-sync.mdx
+++ b/docs/tutorial/03-local-sync.mdx
@@ -69,12 +69,12 @@ import { initTaskList } from "./components/TaskList.tsx";
 // highlight-start
 import {
   Repo,
-  WebSocketClientAdapter,
+  BroadcastChannelNetworkAdapter,
   IndexedDBStorageAdapter,
 } from "@automerge/react";
 
 const repo = new Repo({
-  network: [new WebSocketClientAdapter("wss://sync.automerge.org")],
+  network: [new BroadcastChannelNetworkAdapter()],
   storage: new IndexedDBStorageAdapter(),
 });
 


### PR DESCRIPTION
I just read the documentation and noticed that the text of the tutorial doesn't match the code snippet of that step.

The text mentions using `BroadcastChannelNetworkAdapter`, but the code is already using `WebSocketClientAdapter` that only appears later at the `Network Sync` step.

Note: the fix looks correct to me but I didn't run anything, please check it properly.