### PR TITLE
Example should use BroadcastChannelNetworkAdapter

### DIFF
--- a/docs/tutorial/03-local-sync.mdx
+++ b/docs/tutorial/03-local-sync.mdx
@@ -74,7 +74,7 @@ import {
 } from "@automerge/react";
 
 const repo = new Repo({
-  network: [new WebSocketClientAdapter("wss://sync.automerge.org")],
+  network: [new BroadcastChannelNetworkAdapter()],
   storage: new IndexedDBStorageAdapter(),
 });
 


### PR DESCRIPTION
The text of the document talks about using a `BroadcastChannelNetworkAdapter` as a simple example for getting started but the code sample uses `new WebSocketClientAdapter("wss://sync.automerge.org")`. This works, but makes the demonstration of the `WebSocketClientAdapter` in the Network Sync section somewhat less impressive.