### PR TITLE
Improve change highlighting in 05-react

### DIFF
--- a/docs/tutorial/05-react.mdx
+++ b/docs/tutorial/05-react.mdx
@@ -238,16 +238,16 @@ export const TaskList: React.FC<{
     <>
       <button
         type="button"
+        // highlight-start
         onClick={() => {
-          // highlight-start
           changeDoc((d) =>
             d.tasks.unshift({
               title: "",
               done: false,
             }),
           );
-          // highlight-end
         }}
+        // highlight-end
       >
         <b>+</b> New task
       </button>


### PR DESCRIPTION
"Creating a new Item" in the React Integration step of the tutorial (<https://automerge.org/docs/tutorial/react/#creating-a-new-item>) highlights adding a `onClick` handler as follows:

<img width="991" height="1053" alt="CleanShot 2025-08-16 at 08 59 47" src="https://github.com/user-attachments/assets/e09f63e6-c03a-49f0-9391-7f9f4a1d50fb" />

However, this is the first time that the `onClick` handler is being added.
I believe that the highlight should include adding the onClick property rather than just defining its body.

This is consistent with the "Updating the done state" <https://automerge.org/docs/tutorial/react/#updating-the-done-state> a few lines below.


<img width="999" height="1072" alt="CleanShot 2025-08-16 at 09 03 05" src="https://github.com/user-attachments/assets/2ede8aef-2dd5-439a-b946-bfee5142dba4" />

