### PR TITLE
Generate llms txt

### DIFF
--- a/docs/using-automerge-with-llms.md
+++ b/docs/using-automerge-with-llms.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+---
+
+# Using Automerge with LLMs
+
+We support the [llms.txt](https://llmstxt.org/) standard for making documentation available to large language models.
+
+We offer the following pages:
+
+<!-- needs to be an anchor link, because for markdown links a / is appended at the end -->
+
+- <a href="/llms.txt" target="_blank">`llms.txt`</a> — a listing of the available pages
+- <a href="/llms-full.txt" target="_blank">`llms-full.txt`</a> — complete documentation

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,7 @@ const config = {
         includeOrder: [
           "**/hello.md",
           "**/tutorial/index.md",
-          "**/tutorial/*.mdx",
+          // "**/tutorial/*.mdx", // can be added once https://github.com/rachfop/docusaurus-plugin-llms/issues/15 is fixed
           "**/cookbook/*.md",
           "**/reference/*.md",
           "**/reference/documents/*.md",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   title: "Automerge CRDT",
   tagline:
     "Automerge is a library of data structures for building collaborative applications.",
-  url: "https://automerge.github.io",
+  url: "https://automerge.org",
   baseUrl: "/",
   trailingSlash: true,
   onBrokenLinks: "warn",
@@ -46,6 +46,23 @@ const config = {
             to: "/blog/2025/05/13/automerge-repo-2/",
           },
         ],
+      },
+    ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        includeOrder: [
+          "**/hello.md",
+          "**/tutorial/index.md",
+          "**/tutorial/*.mdx",
+          "**/cookbook/*.md",
+          "**/reference/*.md",
+          "**/reference/documents/*.md",
+          "**/reference/repositories/*.md",
+          "**/reference/under-the-hood/*.md",
+          "**/migrating-from-automerge-2-to-automerge-3.md",
+        ],
+        includeUnmatchedLast: false,
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/mocha": "^10.0.1",
     "@types/uuid": "^9.0.2",
     "clsx": "^1.1.1",
+    "docusaurus-plugin-llms": "^0.1.5",
     "hast-util-is-element": "1.1.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4681,6 +4681,14 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-llms@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.1.5.tgz#0d78c9710557859a5aec16d082588983d750f112"
+  integrity sha512-TKcHQG6MyTTleDdOFJL+5OpmW9Le6XGiagClgSX05GXhxD//4PQlY2Iq9HVETLBIsHVETVp8AxjZQ6e3E/fr/Q==
+  dependencies:
+    gray-matter "^4.0.3"
+    minimatch "^9.0.3"
+
 docusaurus-plugin-typedoc@^0.22.0:
   version "0.22.0"
   resolved "https://registry.npmjs.org/docusaurus-plugin-typedoc/-/docusaurus-plugin-typedoc-0.22.0.tgz"


### PR DESCRIPTION
Can be tested running:

```
yarn build
yarn run serve
```

Then visit:
- http://localhost:3000/docs/using-automerge-with-llms/
- http://localhost:3000/llms.txt
- http://localhost:3000/llms-full.txt

I left out the tutorial since the Urls are wrong until https://github.com/rachfop/docusaurus-plugin-llms/issues/15 is fixed.