### PR TITLE
Update 03-local-sync.mdx

### DIFF
--- a/docs/tutorial/03-local-sync.mdx
+++ b/docs/tutorial/03-local-sync.mdx
@@ -69,12 +69,12 @@ import { initTaskList } from "./components/TaskList.tsx";
 // highlight-start
 import {
   Repo,
-  WebSocketClientAdapter,
+  BroadcastChannelNetworkAdapter,
   IndexedDBStorageAdapter,
 } from "@automerge/react";
 
 const repo = new Repo({
-  network: [new WebSocketClientAdapter("wss://sync.automerge.org")],
+  network: [new BroadcastChannelNetworkAdapter({ channelName: "automerge" })],
   storage: new IndexedDBStorageAdapter(),
 });
 


### PR DESCRIPTION
Update code to use the described BroadcastChannelNetworkAdapter instead of the WebSocketClientAdapter.